### PR TITLE
support Debian Trixie by purging pcregrep

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -33,8 +33,12 @@ class mtail(
     ensure => $ensure,
   }
   # to debug regexes
+  $pcregrep_ensure = $facts['os']['distro']['codename'] ? {
+    'bookworm' => $ensure,
+    default    => 'purged',
+  }
   package { 'pcregrep':
-    ensure => $ensure,
+    ensure => $pcregrep_ensure,
   }
   if $::osfamily == 'Debian' {
     # before BULLSEYE, add mtail from bullseye


### PR DESCRIPTION
Note: the executable in the new package is now called pcre2grep (instead of pcregrep).

See: https://gitlab.torproject.org/tpo/tpa/team/-/issues/42110#note_3187770